### PR TITLE
Factorize integration tests

### DIFF
--- a/python/tests/integration/scripts/test_run_dicom_archive_loader.py
+++ b/python/tests/integration/scripts/test_run_dicom_archive_loader.py
@@ -21,8 +21,8 @@ def test():
             '--tarchive_path', '/data/loris/tarchive/DCM_2015-07-07_ImagingUpload-14-30-FoTt1K.tar',
         ],
         return_code=SUCCESS,
-        stdout_msg=None,
-        stderr_msg=None
+        stdout=None,
+        stderr=None,
     )
 
     # Check that the expected files have been created

--- a/python/tests/integration/scripts/test_run_dicom_archive_validation.py
+++ b/python/tests/integration/scripts/test_run_dicom_archive_validation.py
@@ -20,8 +20,8 @@ def test_missing_upload_id_arg():
             '--tarchive_path', VALID_TARCHIVE_PATH,
         ],
         return_code=MISSING_ARG,
-        stdout_msg="[ERROR   ] argument --upload_id is required",
-        stderr_msg=None
+        stdout="[ERROR   ] argument --upload_id is required",
+        stderr=None,
     )
 
     # Check that the expected data has been inserted in the database
@@ -43,8 +43,8 @@ def test_missing_tarchive_path_arg():
             '--upload_id', VALID_UPLOAD_ID,
         ],
         return_code=MISSING_ARG,
-        stdout_msg="[ERROR   ] argument --tarchive_path is required",
-        stderr_msg=None
+        stdout="[ERROR   ] argument --tarchive_path is required",
+        stderr=None,
     )
 
     # Check that the expected data has been inserted in the database
@@ -65,8 +65,8 @@ def test_invalid_arg():
             '--invalid_arg',
         ],
         return_code=GETOPT_FAILURE,
-        stdout_msg="option --invalid_arg not recognized",
-        stderr_msg=None
+        stdout="option --invalid_arg not recognized",
+        stderr=None,
     )
 
     # Check that the expected data has been inserted in the database
@@ -89,9 +89,9 @@ def test_invalid_tarchive_path_arg():
             '--upload_id', VALID_UPLOAD_ID,
         ],
         return_code=INVALID_PATH,
-        stdout_msg=f"[ERROR   ] {INVALID_TARCHIVE_PATH} does not exist."
+        stdout=f"[ERROR   ] {INVALID_TARCHIVE_PATH} does not exist."
                    f" Please provide a valid path for --tarchive_path",
-        stderr_msg=None
+        stderr=None,
     )
 
     # Check that the expected data has been inserted in the database
@@ -113,8 +113,8 @@ def test_non_existent_upload_id():
             '--upload_id', INVALID_UPLOAD_ID,
         ],
         return_code=SELECT_FAILURE,
-        stdout_msg=None,
-        stderr_msg=f"ERROR: Did not find an entry in mri_upload associated with 'UploadID' {INVALID_UPLOAD_ID}"
+        stdout=None,
+        stderr=f"ERROR: Did not find an entry in mri_upload associated with 'UploadID' {INVALID_UPLOAD_ID}",
     )
 
 
@@ -129,8 +129,8 @@ def test_mixed_up_upload_id_tarchive_path():
             '--upload_id', '126',
         ],
         return_code=SELECT_FAILURE,
-        stdout_msg=None,
-        stderr_msg=f"ERROR: UploadID 126 and ArchiveLocation {VALID_TARCHIVE_PATH} do not refer to the same upload"
+        stdout=None,
+        stderr=f"ERROR: UploadID 126 and ArchiveLocation {VALID_TARCHIVE_PATH} do not refer to the same upload"
     )
 
 
@@ -146,8 +146,8 @@ def test_successful_validation():
             '--upload_id', VALID_UPLOAD_ID,
         ],
         return_code=SUCCESS,
-        stdout_msg=None,
-        stderr_msg=None
+        stdout=None,
+        stderr=None,
     )
 
     # Check that the expected data has been inserted in the database

--- a/python/tests/util/assert_process.py
+++ b/python/tests/util/assert_process.py
@@ -4,9 +4,15 @@ import subprocess
 def assert_process(
     command: list[str],
     return_code: int,
-    stdout_msg: str | None,
-    stderr_msg: str | None
+    stdout: str | None,
+    stderr: str | None,
 ):
+    """
+    Run the provided command and check that its return code, standard output message, and standard
+    error message contain their expected values. A `None` value means that the message must be
+    empty.
+    """
+
     # Run the script to test
     process = subprocess.run(command, capture_output=True, text=True)
 
@@ -14,20 +20,17 @@ def assert_process(
     print(f'STDOUT:\n{process.stdout}')
     print(f'STDERR:\n{process.stderr}')
 
-    # Check that return code, standard error and standard output are correct
+    # Check that the actual return code is equal to the expected return code
     assert process.returncode == return_code
 
-    # Isolate STDOUT message and check that it contains the expected error message
-    if stdout_msg:
-        error_msg_is_valid = True if stdout_msg in process.stdout else False
-        assert error_msg_is_valid is True
+    # Check that the actual output message matches or contains the expected error message
+    if stdout is not None:
+        assert stdout in process.stdout
+    else:
+        assert process.stdout == ""
 
-    # Isolate STDERR message and check that it contains the expected error message
-    if stderr_msg:
-        error_msg_is_valid = True if stderr_msg in process.stderr else False
-        assert error_msg_is_valid is True
-
-    if not stdout_msg:
-        assert process.stdout == b''
-    if not stderr_msg:
-        assert process.stderr == b''
+    # Check that the actual error message matches or contains the expected error message
+    if stderr is not None:
+        assert stderr in process.stderr
+    else:
+        assert process.stderr == ""

--- a/python/tests/util/assert_process.py
+++ b/python/tests/util/assert_process.py
@@ -8,20 +8,20 @@ def assert_process(
     stderr_msg: str | None
 ):
     # Run the script to test
-    process = subprocess.run(command, capture_output=True)
+    process = subprocess.run(command, capture_output=True, text=True)
 
     # Print the standard output and error for debugging
-    print(f'STDOUT:\n{process.stdout.decode()}')
-    print(f'STDERR:\n{process.stderr.decode()}')
+    print(f'STDOUT:\n{process.stdout}')
+    print(f'STDERR:\n{process.stderr}')
 
     # Isolate STDOUT message and check that it contains the expected error message
     if stdout_msg:
-        error_msg_is_valid = True if stdout_msg in process.stdout.decode() else False
+        error_msg_is_valid = True if stdout_msg in process.stdout else False
         assert error_msg_is_valid is True
 
     # Isolate STDERR message and check that it contains the expected error message
     if stderr_msg:
-        error_msg_is_valid = True if stderr_msg in process.stderr.decode() else False
+        error_msg_is_valid = True if stderr_msg in process.stderr else False
         assert error_msg_is_valid is True
 
     # Check that return code, standard error and standard output are correct

--- a/python/tests/util/assert_process.py
+++ b/python/tests/util/assert_process.py
@@ -14,6 +14,9 @@ def assert_process(
     print(f'STDOUT:\n{process.stdout}')
     print(f'STDERR:\n{process.stderr}')
 
+    # Check that return code, standard error and standard output are correct
+    assert process.returncode == return_code
+
     # Isolate STDOUT message and check that it contains the expected error message
     if stdout_msg:
         error_msg_is_valid = True if stdout_msg in process.stdout else False
@@ -24,8 +27,6 @@ def assert_process(
         error_msg_is_valid = True if stderr_msg in process.stderr else False
         assert error_msg_is_valid is True
 
-    # Check that return code, standard error and standard output are correct
-    assert process.returncode == return_code
     if not stdout_msg:
         assert process.stdout == b''
     if not stderr_msg:


### PR DESCRIPTION
List of changes (from most objective to least subjective IMO):
- Use the keyword argument `text=True` in `subprocess.run` to get the output as `str` instead of `bytes` (thus removing the `.decode()` calls).
- Add a docstring to `assert_process` (I am 100% fine with the tests not having docstring, but I'd like this functions that are imported in other modules to have one).
- Test process return code before output, as I think it is the thing you usually want to test first.
- Removed the special case for `""` to treat it like any other string rather than like `None`.
- Rename `stdout/err_msg` to `stdout/err` (subjective, I don't like abbreviations).